### PR TITLE
Little bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ using (var plc = new PLC(CPU_Type.S7300, deviceIpAddress, rackNumber, slotNumber
 ## Running the tests
 
 Unit tests use Snap7 server, so port 102 must be not in use.
-If you have Siemens Step7 installer, the service s7oiehsx64 has to be stopped (this is done automatically inside the constructor of the unit tests).
-You have to restart it manually if you need it.
+If you have Siemens Step7 installed, the service s7oiehsx64 is stopped when running unit tests.
+You have to restart the service manually if you need it.

--- a/S7.Net.UnitTest/S7NetTests.cs
+++ b/S7.Net.UnitTest/S7NetTests.cs
@@ -193,13 +193,17 @@ namespace S7.Net.UnitTest
 
         private static void ShutDownServiceS7oiehsx64()
         {
-            ServiceController sc = new ServiceController("s7oiehsx64");
-            switch (sc.Status)
+            try
             {
-                case ServiceControllerStatus.Running:
-                    sc.Stop();
-                    break;
+                ServiceController sc = new ServiceController("s7oiehsx64");
+                switch (sc.Status)
+                {
+                    case ServiceControllerStatus.Running:
+                        sc.Stop();
+                        break;
+                }
             }
+            catch { } // service not found
         }
 
         #endregion

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -219,10 +219,10 @@ namespace S7.Net
 				LastErrorString = socketException.Message;
 				return null;
 	        }
-            catch
+            catch(Exception exc)
             {
                 LastErrorCode = ErrorCode.WriteData;
-                LastErrorString = "";
+                LastErrorString = exc.Message;
                 return null;
             }
         }


### PR DESCRIPTION
Fixes a problem that prevented unit tests to run on computers without Step7 installed.
Added a message when the ReadBytes method throws a generic exception.