### PR TITLE
An exception occurred but was not handled in user code

### DIFF
--- a/S7.Net.Core/PLC.cs
+++ b/S7.Net.Core/PLC.cs
@@ -243,8 +243,9 @@ namespace S7.Net
 		        package.Add(Types.Word.ToByteArray((ushort) (count)));
 		        package.Add(Types.Word.ToByteArray((ushort) (DB)));
 		        package.Add((byte) dataType);
-		        package.Add((byte) 0);
-		        switch (dataType)
+                var overflow = (int)(startByteAdr * 8 / 0xffffU); // handles words with address bigger than 8191
+                package.Add((byte)overflow);
+                switch (dataType)
 		        {
 			        case DataType.Timer:
 			        case DataType.Counter:
@@ -552,7 +553,8 @@ namespace S7.Net
                 package.Add(Types.Word.ToByteArray((ushort)varCount));
                 package.Add(Types.Word.ToByteArray((ushort)(db)));
                 package.Add((byte)dataType);
-                package.Add((byte)0);
+                var overflow = (int)(startByteAdr * 8 / 0xffffU); // handles words with address bigger than 8191
+                package.Add((byte)overflow);
                 package.Add(Types.Word.ToByteArray((ushort)(startByteAdr * 8)));
                 package.Add(new byte[] { 0, 4 });
                 package.Add(Types.Word.ToByteArray((ushort)(varCount * 8)));

--- a/S7.Net.Core/SocketClient.cs
+++ b/S7.Net.Core/SocketClient.cs
@@ -21,7 +21,7 @@ namespace S7.Net
 
             socketEventArg.RemoteEndPoint = server;
 
-            socketEventArg.Completed += new EventHandler<SocketAsyncEventArgs>(delegate (object s, SocketAsyncEventArgs e)
+            var completedEvent = new EventHandler<SocketAsyncEventArgs>(delegate (object s, SocketAsyncEventArgs e)
             {
                 if (e.SocketError == SocketError.Success)
                 {
@@ -35,11 +35,15 @@ namespace S7.Net
                 _clientDone.Set();
             });
 
+            socketEventArg.Completed += completedEvent;
+
             _clientDone.Reset();
 
             _socket.ConnectAsync(socketEventArg);
 
             _clientDone.WaitOne(TIMEOUT_MILLISECONDS);
+
+            socketEventArg.Completed -= completedEvent;
         }
 
         public void SetReceiveTimeout(int milis)
@@ -63,7 +67,7 @@ namespace S7.Net
                 socketEventArg.RemoteEndPoint = _socket.RemoteEndPoint;
                 socketEventArg.UserToken = null;
 
-                socketEventArg.Completed += new EventHandler<SocketAsyncEventArgs>(delegate (object s, SocketAsyncEventArgs e)
+                var completedEvent = new EventHandler<SocketAsyncEventArgs>(delegate (object s, SocketAsyncEventArgs e)
                 {
                     if (e.SocketError == SocketError.Success)
                     {
@@ -77,6 +81,8 @@ namespace S7.Net
                     _clientDone.Set();
                 });
 
+                socketEventArg.Completed += completedEvent;
+
                 socketEventArg.SetBuffer(buffer, 0, size);
 
                 _clientDone.Reset();
@@ -84,6 +90,8 @@ namespace S7.Net
                 _socket.SendAsync(socketEventArg);
 
                 _clientDone.WaitOne(_sendTimeout);
+
+                socketEventArg.Completed -= completedEvent;
             }
             else
             {
@@ -104,7 +112,7 @@ namespace S7.Net
                 socketEventArg.RemoteEndPoint = _socket.RemoteEndPoint;
                 socketEventArg.SetBuffer(buffer, 0, size);
 
-                socketEventArg.Completed += new EventHandler<SocketAsyncEventArgs>(delegate (object s, SocketAsyncEventArgs e)
+                var completedEvent = new EventHandler<SocketAsyncEventArgs>(delegate (object s, SocketAsyncEventArgs e)
                 {
                     if (e.SocketError == SocketError.Success)
                     {
@@ -118,11 +126,15 @@ namespace S7.Net
                     _clientDone.Set();
                 });
 
+                socketEventArg.Completed += completedEvent;
+
                 _clientDone.Reset();
 
                 _socket.ReceiveAsync(socketEventArg);
 
                 _clientDone.WaitOne(_receiveTimeout);
+
+                socketEventArg.Completed -= completedEvent;
             }
             else
             {
@@ -139,6 +151,8 @@ namespace S7.Net
             if (_socket != null)
             {
                 _socket.Shutdown(SocketShutdown.Both);
+                _socket.Dispose();
+                _socket = null;
             }
         }
 
@@ -148,7 +162,7 @@ namespace S7.Net
 
         private static ManualResetEvent _clientDone = new ManualResetEvent(false);
 
-        private const int TIMEOUT_MILLISECONDS = 5000;
+        private const int TIMEOUT_MILLISECONDS = 1000;
 
     }
 }


### PR DESCRIPTION
Prevent the System.Net.Sockets.SocketAsyncEventArgs.Completed event throw an exception after the time out is called.

> An exception of type 'System.Net.Sockets.SocketException' occurred in S7.Net.Core.dll but was not handled in user code

> Additional information: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond
