### PR TITLE
Read structs recursively

### DIFF
--- a/S7.Net.Common/Types/Struct.cs
+++ b/S7.Net.Common/Types/Struct.cs
@@ -49,6 +49,9 @@ namespace S7.Net.Types
                             numBytes++;
                         numBytes += 4;
                         break;
+                    default:
+                        numBytes += GetStructSize(info.FieldType);
+                        break;
                 }
             }
             return (int)numBytes;
@@ -145,6 +148,14 @@ namespace S7.Net.Types
                                                                            bytes[(int)numBytes + 2],
                                                                            bytes[(int)numBytes + 3] }));
                         numBytes += 4;
+                        break;
+                    default:
+                        var buffer = new byte[GetStructSize(info.FieldType)];
+                        if (buffer.Length == 0)
+                            continue;
+                        Buffer.BlockCopy(bytes, (int)Math.Ceiling(numBytes), buffer, 0, buffer.Length);
+                        info.SetValue(structValue, FromBytes(info.FieldType, buffer));
+                        numBytes += buffer.Length;
                         break;
                 }
             }

--- a/S7.Net.Core/PLC.cs
+++ b/S7.Net.Core/PLC.cs
@@ -804,8 +804,13 @@ namespace S7.Net
 
         public ErrorCode WriteStruct(object structValue, int db)
         {
+            return WriteStruct(structValue, db, 0);
+        }
+
+        public ErrorCode WriteStruct(object structValue, int db, int startByteAdr)
+        {
             var bytes = Types.Struct.ToBytes(structValue).ToList();
-            var errCode = WriteMultipleBytes(bytes, db);
+            var errCode = WriteMultipleBytes(bytes, db, startByteAdr);
             return errCode;
         }
 
@@ -824,8 +829,13 @@ namespace S7.Net
         /// <returns>ErrorCode when writing (NoError if everything was ok)</returns>
         private ErrorCode WriteMultipleBytes(List<byte> bytes, int db)
         {
+            return WriteMultipleBytes(bytes, db, 0);
+        }
+
+        private ErrorCode WriteMultipleBytes(List<byte> bytes, int db, int startByteAdr)
+        {
             ErrorCode errCode = ErrorCode.NoError;
-            int index = 0;
+            int index = startByteAdr;
             try
             {
                 while (bytes.Count > 0)

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -804,8 +804,13 @@ namespace S7.Net
 
         public ErrorCode WriteStruct(object structValue, int db)
         {
+            return WriteStruct(structValue, db, 0);
+        }
+
+        public ErrorCode WriteStruct(object structValue, int db, int startByteAdr)
+        {
             var bytes = Types.Struct.ToBytes(structValue).ToList();
-            var errCode = WriteMultipleBytes(bytes, db);
+            var errCode = WriteMultipleBytes(bytes, db, startByteAdr);
             return errCode;
         }
 
@@ -824,8 +829,13 @@ namespace S7.Net
         /// <returns>ErrorCode when writing (NoError if everything was ok)</returns>
         private ErrorCode WriteMultipleBytes(List<byte> bytes, int db)
         {
+            return WriteMultipleBytes(bytes, db, 0);
+        }
+
+        private ErrorCode WriteMultipleBytes(List<byte> bytes, int db, int startByteAdr)
+        {
             ErrorCode errCode = ErrorCode.NoError;
-            int index = 0;
+            int index = startByteAdr;
             try
             {
                 while (bytes.Count > 0)


### PR DESCRIPTION
To fill Alarm.Time (this example) we need read struct Alarm recursively.

	public struct Alarm
	{
		public byte System;
		public UInt16 Code;
		public DTL Time;
	}

	public struct DTL
	{
		public UInt16 YEAR;
		public byte MONTH;
		public byte DAY;
		public byte WEEKDAY;
		public byte HOUR;
		public byte MINUTE;
		public byte SECOND;
		public UInt32 NANOSECOND;
	}