### PR TITLE
"System.InvalidCastException" on boolean type variable.

### DIFF
--- a/S7.Net.Core/PLC.cs
+++ b/S7.Net.Core/PLC.cs
@@ -701,7 +701,7 @@ namespace S7.Net
                                     throw new Exception(string.Format("Addressing Error: You can only reference bitwise locations 0-7. Address {0} is invalid", mBit));
                                 }
                                 byte b = (byte)Read(DataType.DataBlock, mDB, mByte, VarType.Byte, 1);
-                                if ((int)value == 1)
+                                if (Convert.ToInt32(value) == 1)
                                     b = (byte)(b | (byte)Math.Pow(2, mBit)); // Bit setzen
                                 else
                                     b = (byte)(b & (b ^ (byte)Math.Pow(2, mBit))); // Bit rücksetzen

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -701,7 +701,7 @@ namespace S7.Net
                                     throw new Exception(string.Format("Addressing Error: You can only reference bitwise locations 0-7. Address {0} is invalid", mBit));
                                 }
                                 byte b = (byte)Read(DataType.DataBlock, mDB, mByte, VarType.Byte, 1);
-                                if ((int)value == 1)
+                                if (Convert.ToInt32(value) == 1)
                                     b = (byte)(b | (byte)Math.Pow(2, mBit)); // Bit setzen
                                 else
                                     b = (byte)(b & (b ^ (byte)Math.Pow(2, mBit))); // Bit rücksetzen


### PR DESCRIPTION
Fox example:

plc.Write("DB101.DBX2.2", true);
plc.Write("DB101.DBX2.2", false);

Exception thrown: 'System.InvalidCastException' in S7.Net.dll