### PR TITLE
VS2013 - C# 6 auto-property initializers - issue

### DIFF
--- a/S7.Net.Common/Types/DataItem.cs
+++ b/S7.Net.Common/Types/DataItem.cs
@@ -6,8 +6,13 @@
         public VarType VarType { get; set; }
         public int DB { get; set; }
         public int StartByteAdr { get; set; }
-        public int Count { get; set; } = 1;
+        public int Count { get; set; }
 
         public object Value { get; set; }
+
+        public DataItem()
+        {
+            Count = 1;
+        }
     }
 }


### PR DESCRIPTION
Hi,
I tried to compile the current code with Visual Studio 2013 (Update 3).
The compilation fails because of the use of a C# 6 feature called "auto-property initializers" which is not supported by VS2013 (Update 3) which uses C# 5.0.

One possible fix is to use a constructor.


Regards