### PR TITLE
GetClassSize return zero. Issue #61.

### DIFF
--- a/S7.Net.Core/PLC.cs
+++ b/S7.Net.Core/PLC.cs
@@ -1011,7 +1011,7 @@ namespace S7.Net
             while (numBytes > 0)
             {
                 var maxToRead = (int)Math.Min(numBytes, 200);
-                byte[] bytes = (byte[])Read(DataType.DataBlock, db, index, VarType.Byte, (int)maxToRead);
+                byte[] bytes = ReadBytes(DataType.DataBlock, db, index, maxToRead);
                 if (bytes == null)
                     return new List<byte>();
                 resultBytes.AddRange(bytes);

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -1008,7 +1008,7 @@ namespace S7.Net
             while (numBytes > 0)
             {
                 var maxToRead = (int)Math.Min(numBytes, 200);
-                byte[] bytes = (byte[])Read(DataType.DataBlock, db, index, VarType.Byte, (int)maxToRead);
+                byte[] bytes = ReadBytes(DataType.DataBlock, db, index, maxToRead);
                 if (bytes == null)
                     return new List<byte>();
                 resultBytes.AddRange(bytes);


### PR DESCRIPTION
Fixes bug on ReadMultipleBytes: when readying one byte now it returns byte[] instead of byte.