### PR TITLE
Ignoring properties without a public setter or no setter at all

### DIFF
--- a/S7.Net.UnitTest/Helpers/TestClassWithPrivateSetters.cs
+++ b/S7.Net.UnitTest/Helpers/TestClassWithPrivateSetters.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace S7.Net.UnitTest.Helpers
+{
+    class TestClassWithPrivateSetters : TestClass
+    {
+        public const int PRIVATE_SETTER_VALUE = 42;
+        public const int PROTECTED_SETTER_VALUE = 1337;
+        public const int INTERNAL_SETTER_VALUE = 31137;
+        public const int JUST_A_GETTER_VALUE = 4711;
+
+        public int PrivateSetterProperty
+        {
+            get { return PRIVATE_SETTER_VALUE; }
+            private set { throw new NotSupportedException("Shouldn't access private setter"); }
+        }
+
+        public int ProtectedSetterProperty
+        {
+            get { return PROTECTED_SETTER_VALUE; }
+            private set { throw new NotSupportedException("Shouldn't access protected setter"); }
+        }
+
+        public int InternalSetterProperty
+        {
+            get { return INTERNAL_SETTER_VALUE; }
+            private set { throw new NotSupportedException("Shouldn't access internal setter"); }
+        }
+
+        public int JustAGetterProperty
+        {
+            get { return JUST_A_GETTER_VALUE; }
+        }
+    }
+}

--- a/S7.Net.UnitTest/S7.Net.UnitTest.csproj
+++ b/S7.Net.UnitTest/S7.Net.UnitTest.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Helpers\ConsoleManager.cs" />
     <Compile Include="Helpers\NativeMethods.cs" />
     <Compile Include="Helpers\S7TestServer.cs" />
+    <Compile Include="Helpers\TestClassWithPrivateSetters.cs" />
     <Compile Include="Helpers\TestLongClass.cs" />
     <Compile Include="Snap7\snap7.net.cs" />
     <Compile Include="Helpers\TestClass.cs" />

--- a/S7.Net.UnitTest/S7NetTests.cs
+++ b/S7.Net.UnitTest/S7NetTests.cs
@@ -457,6 +457,37 @@ namespace S7.Net.UnitTest
             Assert.IsFalse(boolVariable);
         }
 
+        [TestMethod]
+        public void T12_ReadClassIgnoresNonPublicSetters()
+        {
+            Assert.IsTrue(plc.IsConnected, "Before executing this test, the plc must be connected. Check constructor.");
+
+            TestClassWithPrivateSetters tc = new TestClassWithPrivateSetters();
+            tc.BitVariable00 = true;
+            tc.BitVariable10 = true;
+            tc.DIntVariable = -100000;
+            tc.IntVariable = -15000;
+            tc.RealVariable = -154.789;
+            tc.DWordVariable = 850;
+
+            plc.WriteClass(tc, DB2);
+
+            TestClassWithPrivateSetters tc2 = new TestClassWithPrivateSetters();
+            // Values that are read from a class are stored inside the class itself, that is passed by reference
+            plc.ReadClass(tc2, DB2);
+            Assert.AreEqual(tc.BitVariable00, tc2.BitVariable00);
+            Assert.AreEqual(tc.BitVariable10, tc2.BitVariable10);
+            Assert.AreEqual(tc.DIntVariable, tc2.DIntVariable);
+            Assert.AreEqual(tc.IntVariable, tc2.IntVariable);
+            Assert.AreEqual(tc.RealVariable, Math.Round(tc2.RealVariable, 3));
+            Assert.AreEqual(tc.DWordVariable, tc2.DWordVariable);
+
+            Assert.AreEqual(TestClassWithPrivateSetters.PRIVATE_SETTER_VALUE, tc2.PrivateSetterProperty);
+            Assert.AreEqual(TestClassWithPrivateSetters.PROTECTED_SETTER_VALUE, tc2.ProtectedSetterProperty);
+            Assert.AreEqual(TestClassWithPrivateSetters.INTERNAL_SETTER_VALUE, tc2.InternalSetterProperty);
+            Assert.AreEqual(TestClassWithPrivateSetters.JUST_A_GETTER_VALUE, tc2.JustAGetterProperty);
+        }
+
         #endregion
 
         #region Private methods

--- a/S7.Net/Types/Class.cs
+++ b/S7.Net/Types/Class.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace S7.Net.Types
@@ -8,16 +10,26 @@ namespace S7.Net.Types
     /// </summary>
     public static class Class
     {
+        private static IEnumerable<PropertyInfo> GetAccessableProperties(Type classType)
+        {
+            return classType
+                .GetProperties(
+                    BindingFlags.SetProperty |
+                    BindingFlags.Public |
+                    BindingFlags.Instance)
+                .Where(p => p.GetSetMethod() != null);
+        }
+
         /// <summary>
-        /// Gets the size of the struct in bytes.
+        /// Gets the size of the class in bytes.
         /// </summary>
         /// <param name="classType">the type of the class</param>
         /// <returns>the number of bytes</returns>
         public static int GetClassSize(Type classType)
         {
-            double numBytes = 0.0;       
-                            
-            var properties = classType.GetProperties();
+            double numBytes = 0.0;
+
+            var properties = GetAccessableProperties(classType);
             foreach (var property in properties)
             {
                 switch (property.PropertyType.Name)
@@ -59,12 +71,11 @@ namespace S7.Net.Types
         }
 
         /// <summary>
-        /// Creates a struct of a specified type by an array of bytes.
+        /// Sets the object's values with the given array of bytes
         /// </summary>
-        /// <param name="sourceClass"></param>
-        /// <param name="classType">The struct type</param>
+        /// <param name="sourceClass">The object to fill in the given array of bytes</param>
+        /// <param name="classType">The class type</param>
         /// <param name="bytes">The array of bytes</param>
-        /// <returns>The object depending on the struct type or null if fails(array-length != struct-length</returns>
         public static void FromBytes(object sourceClass, Type classType, byte[] bytes)
         {
             if (bytes == null)
@@ -79,7 +90,7 @@ namespace S7.Net.Types
             double numBytes = 0.0;
 
 
-            var properties = sourceClass.GetType().GetProperties();
+            var properties = GetAccessableProperties(classType);
             foreach (var property in properties)
             {
                 switch (property.PropertyType.Name)
@@ -181,7 +192,7 @@ namespace S7.Net.Types
             int bitPos = 0;
             double numBytes = 0.0;
 
-            var properties = sourceClass.GetType().GetProperties();
+            var properties = GetAccessableProperties(sourceClass.GetType());
             foreach (var property in properties)
             {
                 bytes2 = null;


### PR DESCRIPTION
The current implementation doesn't support private setters in classes passed into the ReadClass method. I actually think this is a bug and therefore fixed it.