### PR TITLE
Fix communication with WinAC/SoftPLC CPUs and Fix write double

### DIFF
--- a/S7.Net/COTP.cs
+++ b/S7.Net/COTP.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+
+namespace S7.Net
+{
+
+    /// <summary>
+    /// COTP Protocol functions and types
+    /// </summary>
+    internal class COTP
+    {
+        /// <summary>
+        /// Describes a COTP TPDU (Transport protocol data unit)
+        /// </summary>
+        public class TPDU
+        {
+            public byte HeaderLength;
+            public byte PDUType;
+            public int TPDUNumber;
+            public byte[] Data;
+            public bool LastDataUnit;
+
+            public TPDU(TPKT tPKT)
+            {
+                var br = new BinaryReader(new MemoryStream(tPKT.Data));
+                HeaderLength = br.ReadByte();
+                if (HeaderLength >= 2)
+                {
+                    PDUType = br.ReadByte();
+                    if (PDUType == 0xf0) //DT Data
+                    {
+                        var flags = br.ReadByte();
+                        TPDUNumber = flags & 0x7F;
+                        LastDataUnit = (flags & 0x80) > 0;
+                        Data = br.ReadBytes(tPKT.Length - HeaderLength - 4); //4 = TPKT Size
+                        return;
+                    }
+                    //TODO: Handle other PDUTypes
+                }
+                Data = new byte[0];
+            }
+
+            /// <summary>
+            /// Reads COTP TPDU (Transport protocol data unit) from the network stream
+            /// See: https://tools.ietf.org/html/rfc905
+            /// </summary>
+            /// <param name="socket">The socket to read from</param>
+            /// <returns>COTP DPDU instance</returns>
+            public static TPDU Read(Socket socket)
+            {
+                var tpkt = TPKT.Read(socket);
+                return new TPDU(tpkt);
+            }
+
+            public override string ToString()
+            {
+                return string.Format("Length: {0} PDUType: {1} TPDUNumber: {2} Last: {3} Segment Data: {4}",
+                    HeaderLength,
+                    PDUType,
+                    TPDUNumber,
+                    LastDataUnit,
+                    BitConverter.ToString(Data)
+                    );
+            }
+
+        }
+
+        /// <summary>
+        /// Describes a COTP TSDU (Transport service data unit). One TSDU consist of 1 ore more TPDUs
+        /// </summary>
+        public class TSDU
+        {
+            /// <summary>
+            /// Reads the full COTP TSDU (Transport service data unit)
+            /// See: https://tools.ietf.org/html/rfc905
+            /// </summary>
+            /// <returns>Data in TSDU</returns>
+            public static byte[] Read(Socket socket)
+            {                
+                var segment = TPDU.Read(socket);
+                var output = new MemoryStream(segment.Data.Length);
+                output.Write(segment.Data, 0, segment.Data.Length);
+
+                while (!segment.LastDataUnit)
+                {
+                    segment = TPDU.Read(socket);
+                    output.Write(segment.Data, (int)output.Position, segment.Data.Length);
+                }
+                return output.GetBuffer();
+            }
+        }
+    }
+}

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -169,11 +169,27 @@ namespace S7.Net
                 return LastErrorCode;
             }
 
-            try 
+            try
             {
-                byte[] bSend1 = { 3, 0, 0, 22, 17, 224, 0, 0, 0, 46, 0, 193, 2, 1, 0, 194, 2, 3, 0, 192, 1, 9 };
+                byte[] bSend1 = { 3, 0, 0, 22, //TPKT
+                    17,     //COTP Header Length
+                    224,    //Connect Request 
+                    0, 0,   //Destination Reference
+                    0, 46,  //Source Reference
+                    0,      //Flags
+                    193,    //Parameter Code (src-tasp)
+                    2,      //Parameter Length
+                    1, 0,   //Source TASP
+                    194,    //Parameter Code (dst-tasp)
+                    2,      //Parameter Length
+                    3, 0,   //Destination TASP
+                    192,    //Parameter Code (tpdu-size)
+                    1,      //Parameter Length
+                    9       //TPDU Size (2^9 = 512)
+                };
 
-                switch (CPU) {
+                switch (CPU)
+                {
                     case CpuType.S7200:
                         //S7200: Chr(193) & Chr(2) & Chr(16) & Chr(0) 'Eigener Tsap
                         bSend1[11] = 193;

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -4,10 +4,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Net;
-using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using S7.Net.Types;
-using Double = System.Double;
 
 
 namespace S7.Net
@@ -731,7 +729,7 @@ namespace S7.Net
                     package = Types.DWord.ToByteArray((UInt32)value);
                     break;
                 case "Double":
-                    package = Types.Double.ToByteArray((Double)value);
+                    package = Types.Double.ToByteArray((double)value);
                     break;
                 case "Byte[]":
                     package = (byte[])value;
@@ -815,10 +813,12 @@ namespace S7.Net
                                 {
                                     return Write(DataType.DataBlock, mDB, dbIndex, (Int32)value);
                                 }
-                                else
+                                else if (value is double)
                                 {
-                                    objValue = Convert.ChangeType(value, typeof(UInt32));
+                                    return Write(DataType.DataBlock, mDB, dbIndex, value);
                                 }
+
+                                objValue = Convert.ChangeType(value, typeof(UInt32));                                
                                 return Write(DataType.DataBlock, mDB, dbIndex, (UInt32)objValue);
                             case "DBX":
                                 mByte = dbIndex;

--- a/S7.Net/S7.Net.csproj
+++ b/S7.Net/S7.Net.csproj
@@ -77,9 +77,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Conversion.cs" />
+    <Compile Include="COTP.cs" />
     <Compile Include="Enums.cs" />
     <Compile Include="PLC.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TPKT.cs" />
     <Compile Include="Types\Bit.cs" />
     <Compile Include="Types\Boolean.cs" />
     <Compile Include="Types\Byte.cs" />

--- a/S7.Net/TPKT.cs
+++ b/S7.Net/TPKT.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Net.Sockets;
+
+namespace S7.Net
+{
+
+    /// <summary>
+    /// Describes a TPKT Packet
+    /// </summary>
+    internal class TPKT
+    {
+        public byte Version;
+        public byte Reserved1;
+        public int Length;
+        public byte[] Data;
+
+        /// <summary>
+        /// Reds a TPKT from the socket
+        /// </summary>
+        /// <param name="socket">The socket to read from</param>
+        /// <returns>TPKT Instace</returns>
+        public static TPKT Read(Socket socket)
+        {
+            var buf = new byte[4];
+            socket.Receive(buf, 4, SocketFlags.None);
+            var pkt = new TPKT
+            {
+                Version = buf[0],
+                Reserved1 = buf[1],
+                Length = buf[2] * 256 + buf[3] //BigEndian
+            };
+            pkt.Data = new byte[pkt.Length - 4];
+            socket.Receive(pkt.Data, pkt.Length - 4, SocketFlags.None);
+            return pkt;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("Version: {0} Length: {1} Data: {2}",
+                Version,
+                Length,
+                BitConverter.ToString(Data)
+                );
+        }
+    }
+}


### PR DESCRIPTION
Hi

Thanks for this library! I stumbled on some issues when trying to write some values to a SIPROTECT unit (WinAC/LC). 

Issue1: All softPLC based units apparently send out an early "ACK" before most replies that messes with the code. This patch fixes it. The packet in question is "03-00-00-07-02-F0-00". I just wrote a function that trows away this packet if it sees it. 

Issue2: It seems the code for writing single values is broken for some types. When writing double it casts it to a UInt32 and throws away numbers after the decimal point and writes it as a Uint32 on the PLC. This patch fixes this for for double.
