### PR TITLE
Fix miscalculation of ClassSize & StructSize

### DIFF
--- a/S7.Net/Types/Class.cs
+++ b/S7.Net/Types/Class.cs
@@ -99,7 +99,7 @@ namespace S7.Net.Types
                     numBytes = GetIncreasedNumberOfBytes(numBytes, property.PropertyType);
                 }
             }
-            return (int)numBytes;
+            return (int)Math.Ceiling(numBytes);
         }
 
         private static object GetPropertyValue(Type propertyType, byte[] bytes, ref double numBytes)

--- a/S7.Net/Types/Struct.cs
+++ b/S7.Net/Types/Struct.cs
@@ -57,7 +57,7 @@ namespace S7.Net.Types
                         break;
                 }
             }
-            return (int)numBytes;
+            return (int)Math.Ceiling(numBytes);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently if certain datatypes are used, for example boolean you can end up where the remainder is 0.125.  When casting to int, it will truncate and miscalculate the number of bytes to read.  