### PR TITLE
Write short array fix

### DIFF
--- a/S7.Net/Types/Int.cs
+++ b/S7.Net/Types/Int.cs
@@ -45,8 +45,8 @@ namespace S7.Net.Types
 
             for(int i=0; i< value.Length; i++)
             {
-                bytes[bytesPos++] = (byte)((int)value[i] & 0xFF);
-                bytes[bytesPos++] = (byte)(((int)value[i] >> 8) & 0xFF);
+                bytes[bytesPos++] = (byte)((value[i] >> 8) & 0xFF);
+                bytes[bytesPos++] = (byte) (value[i] & 0xFF);
             }
             return bytes;
         }

--- a/S7.Net/Types/Int.cs
+++ b/S7.Net/Types/Int.cs
@@ -29,8 +29,8 @@ namespace S7.Net.Types
         {
             byte[] bytes = new byte[2];
 
-            bytes[1] = (byte)((int)value & 0xFF);
-            bytes[0] = (byte)((int)value >> 8 & 0xFF);
+            bytes[0] = (byte) (value >> 8 & 0xFF);
+            bytes[1] = (byte)(value & 0xFF);
 
             return bytes;
         }


### PR DESCRIPTION
Fixes incorrect byte ordering in `Int.ToByteArray(Int16[] value)`. Fixes #126.