### PR TITLE
Fix the PDU size in communication setup

### DIFF
--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -437,7 +437,7 @@ namespace S7.Net
         private byte[] GetS7ConnectionSetup()
         {
             return new byte[] {  3, 0, 0, 25, 2, 240, 128, 50, 1, 0, 0, 255, 255, 0, 8, 0, 0, 240, 0, 0, 3, 0, 3,
-                    7, 80 //Try 1920 PDU Size. Same as libnodave.
+                    7, 128 //Try 1920 PDU Size. Same as libnodave.
             };
         }
 


### PR DESCRIPTION
[7, 80] resulted in 1872; [7, 128] (or [0x07, 0x80] in hex) results in the 1920 as specified in comments. I'm not sure if this might relate to #128.