### PR TITLE
Fixes invalid TPKT length in request header

### DIFF
--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -177,9 +177,9 @@ namespace S7.Net
         {
             //header size = 19 bytes
             var package = new Types.ByteArray(19);
-            package.Add(new byte[] { 0x03, 0x00, 0x00 });
+            package.Add(new byte[] { 0x03, 0x00 });
             //complete package size
-            package.Add((byte)(19 + (12 * amount)));
+            package.Add(Types.Int.ToByteArray((short)(19 + (12 * amount))));
             package.Add(new byte[] { 0x02, 0xf0, 0x80, 0x32, 0x01, 0x00, 0x00, 0x00, 0x00 });
             //data part size
             package.Add(Types.Word.ToByteArray((ushort)(2 + (amount * 12))));


### PR DESCRIPTION
TPKT length field is actually 2 bytes, so use them correctly.