### PR TITLE
Fix reusing Plc after Close()

### DIFF
--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -194,6 +194,7 @@ namespace S7.Net
                 if (tcpClient.Connected) tcpClient.Close();
                 tcpClient = null; // Can not reuse TcpClient once connection gets closed.
             }
+            _stream = null;
         }
 
         private void AssertPduSizeForRead(ICollection<DataItem> dataItems)


### PR DESCRIPTION
We got a `System.ObjectDisposedException` when trying to access a `Close()`d connection. This is because the cached `Plc._stream` was not reset when its parent `TcpClient` was reset.