### PR TITLE
Fixed TypeHelper

### DIFF
--- a/S7.Net.UnitTest/S7NetTestsSync.cs
+++ b/S7.Net.UnitTest/S7NetTestsSync.cs
@@ -1016,6 +1016,17 @@ namespace S7.Net.UnitTest
         }
 
         [TestMethod]
+        public void T26_ReadWriteDoubles()
+        {
+          double[] test_values = [ 55.66, 89.88 ];
+          plc.Write(DataType.DataBlock, 1, 0, test_values);
+          var result = (double[])plc.Read(DataType.DataBlock, 1, 0, VarType.LReal, 2);
+
+          Assert.AreEqual(test_values[0], result[0], "Compare Write/Read 0");
+          Assert.AreEqual(test_values[1], result[1], "Compare Write/Read 1");
+        }
+
+        [TestMethod]
         public void T27_ReadWriteBytesMany()
         {
             Assert.IsTrue(plc.IsConnected, "Before executing this test, the plc must be connected. Check constructor.");

--- a/S7.Net/Types/TypeHelper.cs
+++ b/S7.Net/Types/TypeHelper.cs
@@ -11,11 +11,12 @@ namespace S7.Net.Types
         /// </summary>
         public static byte[] ToByteArray<T>(T[] value, Func<T, byte[]> converter) where T : struct
         {
-            var buffer = new byte[Marshal.SizeOf(default(T)) * value.Length];
+            var typeSize = Marshal.SizeOf(default(T));
+            var buffer = new byte[typeSize * value.Length];
             var stream = new MemoryStream(buffer);
             foreach (var val in value)
             {
-                stream.Write(converter(val), 0, 4);
+                stream.Write(converter(val), 0, typeSize);
             }
 
             return buffer;


### PR DESCRIPTION
When writing a double[] via Plc.Write/WriteAsync the data that is sent is malformed.

I added a test and found the cause in TypeHelper.ToByteArray(): There is a hard coded 4 when writing the single buffer. This may lead to errors for other types too (not checked that).