### PR TITLE
Struct.cs fix counting length to read

### DIFF
--- a/S7.Net/Types/Struct.cs
+++ b/S7.Net/Types/Struct.cs
@@ -78,7 +78,7 @@ namespace S7.Net.Types
                         break;
                 }
             }
-            return (int)numBytes;
+            return (int)Math.Ceiling(numBytes); 
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed count when there is amount of boolean values which doesn't count up to one byte.