### PR TITLE
Fixed a potential memory leak risk in `MemoryStreamExtension.Write`

### DIFF
--- a/S7.Net/Helper/MemoryStreamExtension.cs
+++ b/S7.Net/Helper/MemoryStreamExtension.cs
@@ -28,10 +28,15 @@ namespace S7.Net.Helper
         {
             byte[] buffer = ArrayPool<byte>.Shared.Rent(value.Length);
 
-            value.CopyTo(buffer);
-            stream.Write(buffer, 0, value.Length);
-
-            ArrayPool<byte>.Shared.Return(buffer);
+            try
+            {
+                value.CopyTo(buffer);
+                stream.Write(buffer, 0, value.Length);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
     }
 #endif


### PR DESCRIPTION
Move the function `ArrayPool<byte>.Shared.Return` to the finally block.